### PR TITLE
fixing theme after last merge

### DIFF
--- a/client/src/muiTheme/theme.js
+++ b/client/src/muiTheme/theme.js
@@ -76,7 +76,6 @@ const theme = createTheme({
       fontWeight: 400,
       lineHeight: "25px",
       color: "#373F41",
-      textTransform: "uppercase",
     },
     body2: {
       fontFamily: ["Roboto", "san-serif"].join(","),
@@ -188,17 +187,25 @@ const theme = createTheme({
         },
       },
     },
-    // Таких properties немає у Default Theme
-    // headerHeight: {
-    //   mobile: "60px",
-    //   desktop: "72px",
-    // },
-    // footerHeight: {
-    //   desktop: "386px",
-    // },
-    // navPanelHeight: {
-    //   mobile: "83px",
-    // },
+    MuiInput: {
+      styleOverrides: {
+        root: {
+          color: "#8C8C8C",
+          fontFamily: "Mulish",
+          fontSize: 16,
+          lineHeight: 24,
+          fontWeight: 300,
+          padding: "15px 0 2px",
+        },
+      },
+    },
+    MuiRadio: {
+      styleOverrides: {
+        root: {
+          color: "#8C8C8C",
+        },
+      },
+    },
   },
   transitions: {
     duration: {


### PR DESCRIPTION
Будь ласка, зроби цей мердж) Відновив тему, бо після мерджу видалилось три параметри:
 MuiStepLabel: {
      styleOverrides: {
        label: {
          fontFamily: ["Mulish", "san-serif"].join(","),
          fontSize: 14,
          fontWeight: 400,
          lineHeight: "24px",
          color: "#949697",
        },
      },
    },
    MuiInput: {
      styleOverrides: {
        root: {
          color: "#8C8C8C",
          fontFamily: "Mulish",
          fontSize: 16,
          lineHeight: 24,
          fontWeight: 300,
          padding: "15px 0 2px",
        },
      },
    },
    MuiRadio: {
      styleOverrides: {
        root: {
          color: "#8C8C8C",
        },
      },
    },
  },